### PR TITLE
add environment variable to proxy subpath of the frontend server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,21 @@ To build the ProxyCrypt image, run:
 
 To run it, put it in your Docker Composition/Swarm/etc., and set these environment variables as needed:
 
-| Variable         | Use                                                                | Default            |
-|:-----------------|:-------------------------------------------------------------------|:-------------------|
-| `PROXY_URL`      | Upstream service in the composition/swarm/etc.                     | (unset, required)  |
-| `CERT_CN`        | Common name for the random certificate, such as `www.myservice.io` | `localhost`        |
-| `CERT_DAYS`      | How many days before the random certificate expires                | `365`              |
-| `PROXY_REDIRECT` | How to rewrite Location and Refresh headers if necessary           | (unset, required)² |
+| Variable         | Use                                                                   | Default            |
+|:-----------------|:----------------------------------------------------------------------|:-------------------|
+| `PROXY_URL`      | Upstream service in the composition/swarm/etc.                        | (unset, required)  |
+| `PROXY_PATH`     | URL path from which the service should be called, e.g. /exposed_path/ | (unset, required)  |
+| `CERT_CN`        | Common name for the random certificate, such as `www.myservice.io`    | `localhost`        |
+| `CERT_DAYS`      | How many days before the random certificate expires                   | `365`              |
+| `PROXY_REDIRECT` | How to rewrite Location and Refresh headers if necessary              | (unset, required)² |
 
 You can also run it locally for testing purposes. Suppose you've got a non-SSL service on TCP port, say, 9200 on your rig. You can run:
 
-    docker container run --env PROXY_URL=http://host.docker.internal:9200/ --publish 8888:443 --rm nasapds/proxycrypt --detach
+    docker container run --env PROXY_URL=http://host.docker.internal:9200/ ---env PROXY_PATH=/exposed_path/ --publish 8888:443 --rm nasapds/proxycrypt --detach
 
 and get an `https` version of that service on port 8888:
 
-    curl --insecure https://localhost:8888/
+    curl --insecure https://localhost:8888/exposed_path
 
 You'll need the `--insecure` (or its equivalent in other applications) since it's a self-signed key.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,6 +46,7 @@ FROM nginx:1.21.6-alpine
 #
 # - CERT_DAYS: How long the random certificate is good for; defaults to 365
 # - PROXY_URL: Where to send upstream requests; this is **required**
+# - PROXY_PATH: Path exposed on the proxy, from which to call the service; this is **required** 
 
 ENV CERT_CN=localhost
 ENV PROXY_REDIRECT=default

--- a/etc/default.conf.template
+++ b/etc/default.conf.template
@@ -47,10 +47,12 @@ server {
     ssl_session_timeout 5m;
 
     # Reverse-proxy
-    location / {
+    location ${PROXY_PATH} {
         proxy_pass       ${PROXY_URL};
         proxy_redirect   ${PROXY_REDIRECT};
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Prefix ${PROXY_PATH};
+	proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This aims at reproducing the production environment where the api is accessed behind path http://pds.nasa.gov/api/search/1

We want to validate that registry-api swagger ui works in such case.

This is used in registry repository see open PR [there](https://github.com/NASA-PDS/registry/pull/144).
