### PR TITLE
add port for the proxy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To run it, put it in your Docker Composition/Swarm/etc., and set these environme
 |:-----------------|:----------------------------------------------------------------------|:-------------------|
 | `PROXY_URL`      | Upstream service in the composition/swarm/etc.                        | (unset, required)  |
 | `PROXY_PATH`     | URL path from which the service should be called, e.g. /exposed_path/ | (unset, required)  |
+| `PROXY_PORT`     | port used by the proxy, as seen by the user                           | (unset, required)  |
 | `CERT_CN`        | Common name for the random certificate, such as `www.myservice.io`    | `localhost`        |
 | `CERT_DAYS`      | How many days before the random certificate expires                   | `365`              |
 | `PROXY_REDIRECT` | How to rewrite Location and Refresh headers if necessary              | (unset, required)² |

--- a/etc/default.conf.template
+++ b/etc/default.conf.template
@@ -52,7 +52,7 @@ server {
         proxy_redirect   ${PROXY_REDIRECT};
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Prefix ${PROXY_PATH};
-	proxy_set_header X-Forwarded-Port $server_port;
+	proxy_set_header X-Forwarded-Port ${PROXY_PORT};
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
add port for the proxy since the port of the nginx server might not be the port the user sees, e.g. with a docker port mapping


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Related to the test of: https://github.com/NASA-PDS/registry-api/issues/211
 



