### PR TITLE
Automatic image construction and publication of Proxycrypt

### DIFF
--- a/.github/workflows/imaging.yaml
+++ b/.github/workflows/imaging.yaml
@@ -1,0 +1,62 @@
+# ProxyCrypt Imaging
+# ==================
+#
+# This workflow builds and registers images of ProxyCrypt.
+
+---
+
+name: 🔑🌁 ProxyCrypt Imaging
+
+
+# Triggers
+# --------
+#
+# Run on any push to the docker or etc subdirs.
+
+on:
+    push:
+        branches:
+            -   main
+        paths:
+            -   'docker/**'
+            -   'etc/**'
+
+
+# Jobs
+# ----
+#
+# What to do.
+
+jobs:
+    imaging:
+        name: 🏞 Imaging
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: 💳 Docker Hub Identification
+                uses: docker/login-action@v2
+                with:
+                    username: ${{secrets.DOCKERHUB_USERNAME}}
+                    password: ${{secrets.DOCKERHUB_TOKEN}}
+            -
+                name: 📚 Repository Checkout
+                uses: actions/checkout@v3
+            -
+                name: 🎰 QEMU Multiple Machine Emulation
+                uses: docker/setup-qemu-action@v2
+            -
+                name: 🚢 Docker Buildx
+                uses: docker/setup-buildx-action@v2
+            -
+                name: 🧱 Image Construction and Publication
+                uses: docker/build-push-action@v4
+                with:
+                    context: .
+                    file: docker/Dockerfile
+                    platforms: linux/amd64,linux/arm64
+                    push: true
+                    tags: ${{secrets.DOCKERHUB_USERNAME}}/proxycrypt:latest
+
+...
+
+# -*- mode: YAML; tab-width: 4 -*-


### PR DESCRIPTION
## 🗒️ Summary

Merge this to get automatic image construction and publication of Proxycrypt, and for multiple platforms (`amd64` and `arm64` Linux so far).

Of the images that go into the Registry's Docker Composition, this was the last one that was not yet multiplatform, which according to [this issue](https://github.com/NASA-PDS/devops/issues/50) prevented you from running the entire Registry stack on `arm64` (such as Apple Silicon—although a workaround could be to install Rosetta2).

## ⚙️ Test Data and/or Report

Left as an exercise to the reader.

## ♻️ Related Issues

- https://github.com/NASA-PDS/devops/issues/50